### PR TITLE
Added logs protobuf parse and validation

### DIFF
--- a/proto/common.proto
+++ b/proto/common.proto
@@ -1,0 +1,89 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package opentelemetry.proto.common.v1;
+
+option csharp_namespace = "OpenTelemetry.Proto.Common.V1";
+option java_multiple_files = true;
+option java_package = "io.opentelemetry.proto.common.v1";
+option java_outer_classname = "CommonProto";
+option go_package = "go.opentelemetry.io/proto/otlp/common/v1";
+
+// AnyValue is used to represent any type of attribute value. AnyValue may contain a
+// primitive value such as a string or integer or it may contain an arbitrary nested
+// object containing arrays, key-value lists and primitives.
+message AnyValue {
+  // The value is one of the listed fields. It is valid for all values to be unspecified
+  // in which case this AnyValue is considered to be "empty".
+  oneof value {
+    string string_value = 1;
+    bool bool_value = 2;
+    int64 int_value = 3;
+    double double_value = 4;
+    ArrayValue array_value = 5;
+    KeyValueList kvlist_value = 6;
+    bytes bytes_value = 7;
+  }
+}
+
+// ArrayValue is a list of AnyValue messages. We need ArrayValue as a message
+// since oneof in AnyValue does not allow repeated fields.
+message ArrayValue {
+  // Array of values. The array may be empty (contain 0 elements).
+  repeated AnyValue values = 1;
+}
+
+// KeyValueList is a list of KeyValue messages. We need KeyValueList as a message
+// since `oneof` in AnyValue does not allow repeated fields. Everywhere else where we need
+// a list of KeyValue messages (e.g. in Span) we use `repeated KeyValue` directly to
+// avoid unnecessary extra wrapping (which slows down the protocol). The 2 approaches
+// are semantically equivalent.
+message KeyValueList {
+  // A collection of key/value pairs of key-value pairs. The list may be empty (may
+  // contain 0 elements).
+  // The keys MUST be unique (it is not allowed to have more than one
+  // value with the same key).
+  repeated KeyValue values = 1;
+}
+
+// KeyValue is a key-value pair that is used to store Span attributes, Link
+// attributes, etc.
+message KeyValue {
+  string key = 1;
+  AnyValue value = 2;
+}
+
+// InstrumentationScope is a message representing the instrumentation scope information
+// such as the fully qualified name and version. 
+message InstrumentationScope {
+  // An empty instrumentation scope name means the name is unknown.
+  string name = 1;
+  string version = 2;
+  repeated KeyValue attributes = 3;
+  uint32 dropped_attributes_count = 4;
+}
+
+// Resource information.
+message Resource {
+  // Set of attributes that describe the resource.
+  // Attribute keys MUST be unique (it is not allowed to have more than one
+  // attribute with the same key).
+  repeated KeyValue attributes = 1;
+
+  // dropped_attributes_count is the number of dropped attributes. If the value is 0, then
+  // no attributes were dropped.
+  uint32 dropped_attributes_count = 2;
+}

--- a/proto/logs.proto
+++ b/proto/logs.proto
@@ -1,0 +1,236 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package opentelemetry.proto.logs.v1;
+
+import "common.proto";
+
+option csharp_namespace = "OpenTelemetry.Proto.Logs.V1";
+option java_multiple_files = true;
+option java_package = "io.opentelemetry.proto.logs.v1";
+option java_outer_classname = "LogsProto";
+option go_package = "go.opentelemetry.io/proto/otlp/logs/v1";
+
+message ExportLogsServiceRequest {
+  // An array of ResourceLogs.
+  // For data coming from a single resource this array will typically contain one
+  // element. Intermediary nodes (such as OpenTelemetry Collector) that receive
+  // data from multiple origins typically batch the data before forwarding further and
+  // in that case this array will contain multiple elements.
+  repeated ResourceLogs resource_logs = 1;
+}
+
+message ExportLogsServiceResponse {
+  // The details of a partially successful export request.
+  //
+  // If the request is only partially accepted
+  // (i.e. when the server accepts only parts of the data and rejects the rest)
+  // the server MUST initialize the `partial_success` field and MUST
+  // set the `rejected_<signal>` with the number of items it rejected.
+  //
+  // Servers MAY also make use of the `partial_success` field to convey
+  // warnings/suggestions to senders even when the request was fully accepted.
+  // In such cases, the `rejected_<signal>` MUST have a value of `0` and
+  // the `error_message` MUST be non-empty.
+  //
+  // A `partial_success` message with an empty value (rejected_<signal> = 0 and
+  // `error_message` = "") is equivalent to it not being set/present. Senders
+  // SHOULD interpret it the same way as in the full success case.
+  ExportLogsPartialSuccess partial_success = 1;
+}
+
+message ExportLogsPartialSuccess {
+  // The number of rejected log records.
+  //
+  // A `rejected_<signal>` field holding a `0` value indicates that the
+  // request was fully accepted.
+  int64 rejected_log_records = 1;
+
+  // A developer-facing human-readable message in English. It should be used
+  // either to explain why the server rejected parts of the data during a partial
+  // success or to convey warnings/suggestions during a full success. The message
+  // should offer guidance on how users can address such issues.
+  //
+  // error_message is an optional field. An error_message with an empty value
+  // is equivalent to it not being set.
+  string error_message = 2;
+}
+
+// LogsData represents the logs data that can be stored in a persistent storage,
+// OR can be embedded by other protocols that transfer OTLP logs data but do not
+// implement the OTLP protocol.
+//
+// The main difference between this message and collector protocol is that
+// in this message there will not be any "control" or "metadata" specific to
+// OTLP protocol.
+//
+// When new fields are added into this message, the OTLP request MUST be updated
+// as well.
+message LogsData {
+  // An array of ResourceLogs.
+  // For data coming from a single resource this array will typically contain
+  // one element. Intermediary nodes that receive data from multiple origins
+  // typically batch the data before forwarding further and in that case this
+  // array will contain multiple elements.
+  repeated ResourceLogs resource_logs = 1;
+}
+
+// A collection of ScopeLogs from a Resource.
+message ResourceLogs {
+  reserved 1000;
+
+  // The resource for the logs in this message.
+  // If this field is not set then resource info is unknown.
+  opentelemetry.proto.common.v1.Resource resource = 1;
+
+  // A list of ScopeLogs that originate from a resource.
+  repeated ScopeLogs scope_logs = 2;
+
+  // This schema_url applies to the data in the "resource" field. It does not apply
+  // to the data in the "scope_logs" field which have their own schema_url field.
+  string schema_url = 3;
+}
+
+// A collection of Logs produced by a Scope.
+message ScopeLogs {
+  // The instrumentation scope information for the logs in this message.
+  // Semantically when InstrumentationScope isn't set, it is equivalent with
+  // an empty instrumentation scope name (unknown).
+  opentelemetry.proto.common.v1.InstrumentationScope scope = 1;
+
+  // A list of log records.
+  repeated LogRecord log_records = 2;
+
+  // This schema_url applies to all logs in the "logs" field.
+  string schema_url = 3;
+}
+
+// Possible values for LogRecord.SeverityNumber.
+enum SeverityNumber {
+  // UNSPECIFIED is the default SeverityNumber, it MUST NOT be used.
+  SEVERITY_NUMBER_UNSPECIFIED = 0;
+  SEVERITY_NUMBER_TRACE  = 1;
+  SEVERITY_NUMBER_TRACE2 = 2;
+  SEVERITY_NUMBER_TRACE3 = 3;
+  SEVERITY_NUMBER_TRACE4 = 4;
+  SEVERITY_NUMBER_DEBUG  = 5;
+  SEVERITY_NUMBER_DEBUG2 = 6;
+  SEVERITY_NUMBER_DEBUG3 = 7;
+  SEVERITY_NUMBER_DEBUG4 = 8;
+  SEVERITY_NUMBER_INFO   = 9;
+  SEVERITY_NUMBER_INFO2  = 10;
+  SEVERITY_NUMBER_INFO3  = 11;
+  SEVERITY_NUMBER_INFO4  = 12;
+  SEVERITY_NUMBER_WARN   = 13;
+  SEVERITY_NUMBER_WARN2  = 14;
+  SEVERITY_NUMBER_WARN3  = 15;
+  SEVERITY_NUMBER_WARN4  = 16;
+  SEVERITY_NUMBER_ERROR  = 17;
+  SEVERITY_NUMBER_ERROR2 = 18;
+  SEVERITY_NUMBER_ERROR3 = 19;
+  SEVERITY_NUMBER_ERROR4 = 20;
+  SEVERITY_NUMBER_FATAL  = 21;
+  SEVERITY_NUMBER_FATAL2 = 22;
+  SEVERITY_NUMBER_FATAL3 = 23;
+  SEVERITY_NUMBER_FATAL4 = 24;
+}
+
+// Masks for LogRecord.flags field.
+enum LogRecordFlags {
+  LOG_RECORD_FLAG_UNSPECIFIED = 0;
+  LOG_RECORD_FLAG_TRACE_FLAGS_MASK = 0x000000FF;
+}
+
+// A log record according to OpenTelemetry Log Data Model:
+// https://github.com/open-telemetry/oteps/blob/main/text/logs/0097-log-data-model.md
+message LogRecord {
+  reserved 4;
+
+  // time_unix_nano is the time when the event occurred.
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
+  // Value of 0 indicates unknown or missing timestamp.
+  fixed64 time_unix_nano = 1;
+
+  // Time when the event was observed by the collection system.
+  // For events that originate in OpenTelemetry (e.g. using OpenTelemetry Logging SDK)
+  // this timestamp is typically set at the generation time and is equal to Timestamp.
+  // For events originating externally and collected by OpenTelemetry (e.g. using
+  // Collector) this is the time when OpenTelemetry's code observed the event measured
+  // by the clock of the OpenTelemetry code. This field MUST be set once the event is
+  // observed by OpenTelemetry.
+  //
+  // For converting OpenTelemetry log data to formats that support only one timestamp or
+  // when receiving OpenTelemetry log data by recipients that support only one timestamp
+  // internally the following logic is recommended:
+  //   - Use time_unix_nano if it is present, otherwise use observed_time_unix_nano.
+  //
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
+  // Value of 0 indicates unknown or missing timestamp.
+  fixed64 observed_time_unix_nano = 11;
+
+  // Numerical value of the severity, normalized to values described in Log Data Model.
+  // [Optional].
+  SeverityNumber severity_number = 2;
+
+  // The severity text (also known as log level). The original string representation as
+  // it is known at the source. [Optional].
+  string severity_text = 3;
+
+  // A value containing the body of the log record. Can be for example a human-readable
+  // string message (including multi-line) describing the event in a free form or it can
+  // be a structured data composed of arrays and maps of other values. [Optional].
+  opentelemetry.proto.common.v1.AnyValue body = 5;
+
+  // Additional attributes that describe the specific event occurrence. [Optional].
+  // Attribute keys MUST be unique (it is not allowed to have more than one
+  // attribute with the same key).
+  repeated opentelemetry.proto.common.v1.KeyValue attributes = 6;
+  uint32 dropped_attributes_count = 7;
+
+  // Flags, a bit field. 8 least significant bits are the trace flags as
+  // defined in W3C Trace Context specification. 24 most significant bits are reserved
+  // and must be set to 0. Readers must not assume that 24 most significant bits
+  // will be zero and must correctly mask the bits when reading 8-bit trace flag (use
+  // flags & TRACE_FLAGS_MASK). [Optional].
+  fixed32 flags = 8;
+
+  // A unique identifier for a trace. All logs from the same trace share
+  // the same `trace_id`. The ID is a 16-byte array. An ID with all zeroes OR
+  // of length other than 16 bytes is considered invalid (empty string in OTLP/JSON
+  // is zero-length and thus is also invalid).
+  //
+  // This field is optional.
+  //
+  // The receivers SHOULD assume that the log record is not associated with a
+  // trace if any of the following is true:
+  //   - the field is not present,
+  //   - the field contains an invalid value.
+  bytes trace_id = 9;
+
+  // A unique identifier for a span within a trace, assigned when the span
+  // is created. The ID is an 8-byte array. An ID with all zeroes OR of length
+  // other than 8 bytes is considered invalid (empty string in OTLP/JSON
+  // is zero-length and thus is also invalid).
+  //
+  // This field is optional. If the sender specifies a valid span_id then it SHOULD also
+  // specify a valid trace_id.
+  //
+  // The receivers SHOULD assume that the log record is not associated with a
+  // span if any of the following is true:
+  //   - the field is not present,
+  //   - the field contains an invalid value.
+  bytes span_id = 10;
+}

--- a/proto/metrics.proto
+++ b/proto/metrics.proto
@@ -16,77 +16,13 @@ syntax = "proto3";
 
 package opentelemetry.proto.metrics.v1;
 
+import "common.proto";
+
 option csharp_namespace = "OpenTelemetry.Proto.Metrics.V1";
 option java_multiple_files = true;
 option java_package = "io.opentelemetry.proto.metrics.v1";
 option java_outer_classname = "MetricsProto";
 option go_package = "go.opentelemetry.io/proto/otlp/metrics/v1";
-
-// AnyValue is used to represent any type of attribute value. AnyValue may contain a
-// primitive value such as a string or integer or it may contain an arbitrary nested
-// object containing arrays, key-value lists and primitives.
-message AnyValue {
-  // The value is one of the listed fields. It is valid for all values to be unspecified
-  // in which case this AnyValue is considered to be "empty".
-  oneof value {
-    string string_value = 1;
-    bool bool_value = 2;
-    int64 int_value = 3;
-    double double_value = 4;
-    ArrayValue array_value = 5;
-    KeyValueList kvlist_value = 6;
-    bytes bytes_value = 7;
-  }
-}
-
-// ArrayValue is a list of AnyValue messages. We need ArrayValue as a message
-// since oneof in AnyValue does not allow repeated fields.
-message ArrayValue {
-  // Array of values. The array may be empty (contain 0 elements).
-  repeated AnyValue values = 1;
-}
-
-// KeyValueList is a list of KeyValue messages. We need KeyValueList as a message
-// since `oneof` in AnyValue does not allow repeated fields. Everywhere else where we need
-// a list of KeyValue messages (e.g. in Span) we use `repeated KeyValue` directly to
-// avoid unnecessary extra wrapping (which slows down the protocol). The 2 approaches
-// are semantically equivalent.
-message KeyValueList {
-  // A collection of key/value pairs of key-value pairs. The list may be empty (may
-  // contain 0 elements).
-  // The keys MUST be unique (it is not allowed to have more than one
-  // value with the same key).
-  repeated KeyValue values = 1;
-}
-
-// KeyValue is a key-value pair that is used to store Span attributes, Link
-// attributes, etc.
-message KeyValue {
-  string key = 1;
-  AnyValue value = 2;
-}
-
-// InstrumentationScope is a message representing the instrumentation scope information
-// such as the fully qualified name and version. 
-message InstrumentationScope {
-  // An empty instrumentation scope name means the name is unknown.
-  string name = 1;
-  string version = 2;
-  repeated KeyValue attributes = 3;
-  uint32 dropped_attributes_count = 4;
-}
-
-// Resource information.
-message Resource {
-  // Set of attributes that describe the resource.
-  // Attribute keys MUST be unique (it is not allowed to have more than one
-  // attribute with the same key).
-  repeated KeyValue attributes = 1;
-
-  // dropped_attributes_count is the number of dropped attributes. If the value is 0, then
-  // no attributes were dropped.
-  uint32 dropped_attributes_count = 2;
-}
 
 message ExportMetricsServiceRequest {
   // An array of ResourceMetrics.
@@ -158,7 +94,7 @@ message ResourceMetrics {
 
   // The resource for the metrics in this message.
   // If this field is not set then no resource info is known.
-  Resource resource = 1;
+  opentelemetry.proto.common.v1.Resource resource = 1;
 
   // A list of metrics that originate from a resource.
   repeated ScopeMetrics scope_metrics = 2;
@@ -173,7 +109,7 @@ message ScopeMetrics {
   // The instrumentation scope information for the metrics in this message.
   // Semantically when InstrumentationScope isn't set, it is equivalent with
   // an empty instrumentation scope name (unknown).
-  InstrumentationScope scope = 1;
+  opentelemetry.proto.common.v1.InstrumentationScope scope = 1;
 
   // A list of metrics that originate from an instrumentation library.
   repeated Metric metrics = 2;
@@ -446,7 +382,7 @@ message NumberDataPoint {
   // where this point belongs. The list may be empty (may contain 0 elements).
   // Attribute keys MUST be unique (it is not allowed to have more than one
   // attribute with the same key).
-  repeated KeyValue attributes = 7;
+  repeated opentelemetry.proto.common.v1.KeyValue attributes = 7;
 
   // StartTimeUnixNano is optional but strongly encouraged, see the
   // the detailed comments above Metric.
@@ -494,7 +430,7 @@ message HistogramDataPoint {
   // where this point belongs. The list may be empty (may contain 0 elements).
   // Attribute keys MUST be unique (it is not allowed to have more than one
   // attribute with the same key).
-  repeated KeyValue attributes = 9;
+  repeated opentelemetry.proto.common.v1.KeyValue attributes = 9;
 
   // StartTimeUnixNano is optional but strongly encouraged, see the
   // the detailed comments above Metric.
@@ -573,7 +509,7 @@ message ExponentialHistogramDataPoint {
   // where this point belongs. The list may be empty (may contain 0 elements).
   // Attribute keys MUST be unique (it is not allowed to have more than one
   // attribute with the same key).
-  repeated KeyValue attributes = 1;
+  repeated opentelemetry.proto.common.v1.KeyValue attributes = 1;
 
   // StartTimeUnixNano is optional but strongly encouraged, see the
   // the detailed comments above Metric.
@@ -688,7 +624,7 @@ message SummaryDataPoint {
   // where this point belongs. The list may be empty (may contain 0 elements).
   // Attribute keys MUST be unique (it is not allowed to have more than one
   // attribute with the same key).
-  repeated KeyValue attributes = 7;
+  repeated opentelemetry.proto.common.v1.KeyValue attributes = 7;
 
   // StartTimeUnixNano is optional but strongly encouraged, see the
   // the detailed comments above Metric.
@@ -754,7 +690,7 @@ message Exemplar {
   // The set of key/value pairs that were filtered out by the aggregator, but
   // recorded alongside the original measurement. Only key/value pairs that were
   // filtered out by the aggregator should be included
-  repeated KeyValue filtered_attributes = 7;
+  repeated opentelemetry.proto.common.v1.KeyValue filtered_attributes = 7;
 
   // time_unix_nano is the exact time when this exemplar was recorded
   //

--- a/src/opentelemetry_types/common.rs
+++ b/src/opentelemetry_types/common.rs
@@ -1,0 +1,1 @@
+include!(concat!(env!("OUT_DIR"), "/proto/common.rs"));

--- a/src/opentelemetry_types/logs.rs
+++ b/src/opentelemetry_types/logs.rs
@@ -1,0 +1,1 @@
+include!(concat!(env!("OUT_DIR"), "/proto/logs.rs"));

--- a/src/validation/logs.rs
+++ b/src/validation/logs.rs
@@ -1,0 +1,72 @@
+use url::Url;
+
+use crate::opentelemetry::logs::{ExportLogsServiceRequest, LogRecord, ResourceLogs, ScopeLogs};
+
+use crate::validation::common::*;
+
+pub trait LogValidate {
+    fn validate(&self) -> Result<(), crate::Error>;
+}
+
+impl LogValidate for ExportLogsServiceRequest<'_> {
+    fn validate(&self) -> Result<(), crate::Error> {
+        for resource_log in &self.resource_logs {
+            resource_log.validate()?;
+        }
+
+        Ok(())
+    }
+}
+
+impl LogValidate for ResourceLogs<'_> {
+    fn validate(&self) -> Result<(), crate::Error> {
+        match &self.resource {
+            Some(resource) => resource.validate(),
+            None => Ok(()),
+        }?;
+
+        for scope_log in &self.scope_logs {
+            scope_log.validate()?;
+        }
+
+        if self.schema_url != "" {
+            Url::parse(self.schema_url.as_ref())?;
+        }
+
+        Ok(())
+    }
+}
+
+impl LogValidate for ScopeLogs<'_> {
+    fn validate(&self) -> Result<(), crate::Error> {
+        match &self.scope {
+            Some(scope) => scope.validate(),
+            None => Ok(()),
+        }?;
+
+        for log_record in &self.log_records {
+            log_record.validate()?;
+        }
+
+        if self.schema_url != "" {
+            Url::parse(self.schema_url.as_ref())?;
+        }
+
+        Ok(())
+    }
+}
+
+impl LogValidate for LogRecord<'_> {
+    fn validate(&self) -> Result<(), crate::Error> {
+        match &self.body {
+            Some(body) => body.validate(),
+            None => Ok(()),
+        }?;
+
+        for attribute in &self.attributes {
+            attribute.validate()?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/validation/mod.rs
+++ b/src/validation/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod common;
+pub(crate) mod logs;
 pub(crate) mod metrics;


### PR DESCRIPTION
Added OpenTelemetry logs protobuf decoding and validation.
A metrics prototype has been separated into common and metrics as part of this PR.
The common contains prototype used in both logs and metrics.

Ref: LOG-16657