### PR TITLE
fix(ci): Do not run test release on main branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,6 +60,11 @@ pipeline {
     }
 
     stage('Commitlint and dry release'){
+      when {
+        not {
+          branch DEFAULT_BRANCH
+        }
+      }
       tools {
         nodejs 'NodeJS 20'
       }


### PR DESCRIPTION
If we're on `main`, we're probably doing a release, so skip the release test.

Ref: LOG-19546